### PR TITLE
Do not overwrite global tags with metric specific tags.

### DIFF
--- a/lib/appoptics.js
+++ b/lib/appoptics.js
@@ -249,6 +249,10 @@ var flushStats = function appopticsFlush(ts, metrics) {
     var match;
     var measureName = measure.name;
     measure.tags = {};
+    // Also include the the global tags:
+    for (var tag in tags) {
+      measure.tags[tag] = tags[tag];
+    }
     measureName = parseAndSetTags(measureName, measure);
     // Use first capturing group as source name.
     // NOTE: Only legacy users will a) have a source and b) have a source set by regex


### PR DESCRIPTION
Previously, adding a tag an a specific metric (Like described in the tags section: metric.name#tag1=value,tag2=value:value) would overwrite the global tags added in the StastD config file.
This change will append the metric specific tags, sending all tags to AppOptics.